### PR TITLE
docs: Add Quickstart and MCP Security Glossary with Technique Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ SAFE-MCP is a comprehensive security framework for documenting and mitigating th
 3. **Compliance Officers**: Map SAFE-MCP techniques to your existing security controls via MITRE ATT&CK linkages
 4. **Red Teams**: Reference attack techniques for security testing of MCP deployments
 
+## Documentation
+
+- [Security Quickstart Guide](docs/quickstart.md) - Step-by-step guide for securing MCP deployments  
+- [Security Glossary](docs/glossary.md) - Standardized terminology and technique links
+
+For comprehensive technique details, see the TTP Reference Table below.
 ## TTP Reference Table
 
 This table provides a comprehensive reference of all Tactics, Techniques, and Procedures (TTPs) defined in the SAFE-MCP framework.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,57 @@
+# MCP Security Glossary
+
+*Standardized terminology following MITRE ATT&CK methodology*
+
+## Core MCP Components
+
+### Host
+**Definition**: The system or environment where MCP (Model Context Protocol) components are deployed and executed.
+**MCP Context**: Includes the runtime environment, dependencies, and security boundaries for MCP operations.
+**Related Techniques**: Host-based attacks, privilege escalation
+
+### Server
+**Definition**: The backend component that processes MCP requests and manages tool interactions.
+**MCP Context**: Handles authentication, authorization, and tool execution within the MCP framework.
+**Related Techniques**: [SAFE-T1102 Prompt Injection](../techniques/), Server-side request forgery
+
+### Tool
+**Definition**: Specific capabilities or functions exposed through the MCP interface.
+**MCP Context**: Individual tools represent discrete operations (file access, API calls, etc.) available to MCP clients.
+**Related Techniques**: Tool misuse, unauthorized tool access
+
+## Authentication & Authorization
+
+### OAuth AS (Authorization Server)
+**Definition**: OAuth 2.0 Authorization Server responsible for issuing access tokens for MCP resources.
+**MCP Context**: Manages authentication flows and scope-based access control for MCP tools and services.
+**Related Techniques**: Token theft, authorization bypass
+
+### PoP/DPoP (Proof of Possession/Demonstration of Proof of Possession)
+**Definition**: Cryptographic mechanisms to bind access tokens to specific clients or requests.
+**MCP Context**: Prevents token replay attacks and ensures token usage by legitimate MCP clients only.
+**Related Techniques**: Token binding, replay attack prevention
+
+### Scope
+**Definition**: Access control mechanism defining what resources and operations a client can access.
+**MCP Context**: Limits MCP tool access based on granted permissions and use case requirements.
+**Related Techniques**: Scope escalation, privilege creep
+
+### Audience
+**Definition**: Intended recipient or target system for authentication tokens or MCP requests.
+**MCP Context**: Ensures MCP communications are directed to appropriate endpoints and services.
+**Related Techniques**: Token misdirection, audience confusion
+
+## Operational Security
+
+### Context Window
+**Definition**: The scope of information and history available to MCP operations at any given time.
+**MCP Context**: Manages data retention, privacy boundaries, and information flow within MCP sessions.
+**Related Techniques**: [SAFE-T1102 Prompt Injection](../techniques/), Context manipulation, information leakage
+
+### Autonomous Loop Guard
+**Definition**: Security control preventing infinite or runaway automated operations in MCP systems.
+**MCP Context**: Protects against resource exhaustion and uncontrolled MCP tool execution loops.
+**Related Techniques**: Resource exhaustion, denial of service, loop exploitation
+
+---
+*This glossary standardizes terminology across teams and links to specific security techniques and mitigations.*

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,35 @@
+# MCP Security Quickstart Guide
+
+## For Security Teams
+
+### 1. Pick Relevant Tactics + Map to Your MCP Tools
+- Identify your MCP tools and components in your environment
+- Map potential attack vectors using our [Security Glossary](./glossary.md)
+- Focus on high-risk areas first
+
+### 2. Apply Mitigations
+- Review technique-specific mitigations (e.g., [SAFE-T1102 Prompt Injection](../techniques/prompt-injection.md))
+- Implement recommended security controls
+- Configure OAuth AS and PoP/DPoP appropriately
+
+### 3. Run Security Checks
+- Validate configurations against security checklist
+- Monitor for autonomous loop guard triggers
+- Regular security assessments
+
+## For Developers
+
+### Getting Started with Secure MCP Development
+1. **Understand scope and audience parameters** for your MCP tools
+2. **Implement proper context window management**
+3. **Follow secure coding practices** outlined in our guidelines
+4. **Test security controls** before deployment
+
+### Key Security Checkpoints
+- [ ] OAuth AS properly configured
+- [ ] Scope limitations implemented  
+- [ ] Context window boundaries set
+- [ ] Autonomous loop guards active
+
+---
+*This quickstart improves adoption and standardizes terminology across security teams and developers.*


### PR DESCRIPTION
## Summary
Addresses #47 by adding comprehensive quickstart documentation and security glossary.

## Changes
-  Added step-by-step quickstart guide for security teams/developers
-  Created MCP Security Glossary with standardized terminology  
-  Linked glossary terms to specific techniques (SAFE-T1102 Prompt Injection → mitigations)
-  Followed MITRE ATT&CK formatting methodology

## Why
- Improves adoption by providing hands-on guidance
- Standardizes terminology across teams
- Creates clear technique-to-mitigation mappings

@bishnubista Ready for review as requested!

Closes #47